### PR TITLE
更新process_test.go 并且找出外部调用错误

### DIFF
--- a/protocol_api_test.go
+++ b/protocol_api_test.go
@@ -1,0 +1,30 @@
+package gop2p
+
+import (
+	"testing"
+	"net/rpc/jsonrpc"
+//	"fmt"
+	"log"
+)
+
+func cmdHandle(methodName string, args interface{}, reply interface{}) error {
+	client, err := jsonrpc.Dial("tcp", ":1025")
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	err = client.Call("RPCCommandServer." + methodName, args, &reply)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func TestApi(t *testing.T) {
+	err := cmdHandle("Api", nil, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -3,40 +3,23 @@ package gop2p
 import (
 	"testing"
 	"net"
+	"net/rpc"
+	"net/rpc/jsonrpc"
 //	"time"
 	"fmt"
 	"log"
 )
 
-/*
-type netEvent struct {
-	args [5]*interface{}
-}
-
-func (e *netEvent) OnRequest (args ...interface{}) error {
-	e.args[
-}
-
-func (e *netEvent) OnNotice (args ...interface{}) error {
-}
-
-func (e *netEvent) OnOK (args ...interface{}) error {
-}
-
-func (e *netEvent) OnTurning (args ...interface{}) error {
-}
-
-func (e *netEvent) OnNotice2 (args ...interface{}) error {
-}
-*/
-
 var event *Event_T
+
+type RPCCommandServer struct {}
 
 func init() {
 	event = &Event_T{}
 	event.Args[0] = [2]string{"on request", "hi hi hi"}
 	event.Args[1] = "on Notice"
-	event.Args[2] = [2]interface{}{"on OK", syncron}
+//	event.Args[2] = [2]interface{}{"on OK", syncron}
+	event.Args[2] = [2]interface{}{"on OK", nil}
 	event.Args[3] = "on Turning"
 	event.Args[4] = "on Notice 2"
 
@@ -44,17 +27,25 @@ func init() {
 		for _, v := range event.Args[command].([2]string) {
 			fmt.Println(v)
 		}
+
+		AddPeer(innerArgs[0].(*net.TCPConn)) // 如果穿透服也是一个节点，则可以执行此
 		return nil
 	}
 
 	event.OnNotice = func(command int, innerArgs ...interface{}) error {
 		fmt.Println(event.Args[command])
+		AddPeer(innerArgs[0].(*net.TCPConn)) // 如果穿透服也是一个节点，则可以执行此
+
+		// event.SeedConn.Close() // 如果穿透服不是一个节点，则关闭
+		// event.SeedConn的赋值 在gop2p 内部完成
+
 		return nil
 	}
 
 	event.OnOK = func(command int, innerArgs ...interface{}) error {
 		fmt.Println(event.Args[command].([2]interface{})[0])
-		event.Args[command].([2]interface{})[1].(func() error)()
+		fmt.Println("peers:", GetPeers())
+	//	event.Args[command].([2]interface{})[1].(func() error)()
 		return nil
 	}
 
@@ -65,22 +56,29 @@ func init() {
 
 	event.OnNotice2 = func(command int, innerArgs ...interface{}) error {
 		fmt.Println(event.Args[command])
+		AddPeer(innerArgs[0].(*net.TCPConn)) // 如果穿透服也是一个节点，则可以执行此
+
+		// event.SeedConn.Close() // 如果穿透服不是一个节点，则关闭
+		// event.SeedConn的赋值 在gop2p 内部完成
 		return nil
 	}
 }
 
 func TestMain(t *testing.T) {
-
 	seeds := []string {
-		"121.41.85.45:34009",
+		"121.41.85.45:39991",
 	}
 
-//	go sendDemo(t)
+	go func() {
+		err := startRPCCommandServer()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	err := StartTCPTurnServer(seeds, event, processLogic)
-//	err := StartTCPTurnServer(seeds, eventsArrayFunc, processLogic)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 }
 
@@ -98,46 +96,44 @@ func syncron() error {
 func processLogic(api int, data []byte, conn *net.TCPConn) error {
 	switch api {
 	case 0:
-		log.Println("case 0:", string(data))
+		log.Println("api 0:", string(data))
 	case 1:
-		log.Println("case 1:", string(data))
+		log.Println("api 1:", string(data))
 	}
 
 	return nil
 }
 
-	/*
-func sendDemo(t *testing.T) {
-	time.Sleep(time.Second * 5)
-
-	t.Log("sendDemo...")
-	for k, _ := range peers {
-		t.Log("conn:", k.LocalAddr(), k.RemoteAddr())
-		body := intToBytes(0)
-		body = append(body, []byte("hi hi hi")...)
-		sendData := []byte(PACKET_IDENTIFY)
-		sendData = append(sendData, intToBytes(ACTION_CONNECTION_LOGIC)...)
-		sendData = append(sendData, intToBytes(len(body))...)
-		sendData = append(sendData, body...)
-		n, err := k.Write(sendData)
-		if err != nil {
-			t.Log(err)
-			break
-		}
-		log.Println("n:", n)
-
-		body = intToBytes(1)
-		body = append(body, []byte("hello hello hello")...)
-		sendData = []byte(PACKET_IDENTIFY)
-		sendData = append(sendData, intToBytes(ACTION_CONNECTION_LOGIC)...)
-		sendData = append(sendData, intToBytes(len(body))...)
-		sendData = append(sendData, body...)
-		n, err = k.Write(sendData)
-		if err != nil {
-			t.Log(err)
-			break
-		}
-		log.Println("n:", n)
-	}
+func broadcast(api int, data []byte) error {
+	return nil
 }
-	*/
+
+func (c *RPCCommandServer)Api(args interface{}, reply *string) error {
+	log.Println("conns:", GetPeers())
+	Broadcast(5, []byte("testInfo"))
+
+	return nil
+}
+
+func startRPCCommandServer() error {
+	rpc.Register(&RPCCommandServer{})
+
+	ln, err := net.Listen("tcp", ":1025")
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+	log.Println("rpc service is listening on port 1025")
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			log.Println(err, conn)
+			continue
+		}
+
+		jsonrpc.ServeConn(conn)
+	}
+
+	return nil
+}

--- a/protocol_unix.go
+++ b/protocol_unix.go
@@ -94,15 +94,13 @@ func connectSeed(lAddr *net.TCPAddr, seedAddrsStr []string, event *Event_T, proc
 		data = append(data, intToBytes(ACTION_CONNECTION_REQUEST)...)
 		data = append(data, intToBytes(len(body))...)
 		data = append(data, body...)
-		log.Println(data)
 
 		go handleTCPConnection(connc.(*net.TCPConn), event, processLogic)
-		n, err := connc.Write(data)
+		_, err = connc.Write(data)
 		if err != nil {
 			log.Println(err)
 			continue
 		}
-		log.Println(n)
 	}
 
 	return nil
@@ -221,7 +219,7 @@ func tcpHandle(command int, data []byte, conn *net.TCPConn, event *Event_T, proc
 		source:B distination:S
 	*/
 	case ACTION_CONNECTION_REQUEST:
-		log.Println("case 0:", data)
+		log.Println("case 0:")
 		for k, v := range comingConns {
 			log.Println(k.LocalAddr(), k.RemoteAddr(), v)
 		}


### PR DESCRIPTION
外部调用错误:广播时应当直接使用gop2p.Broadcast, 不要在循环内使用gop2p.Send
添加protocol_api_test.go 作为rpc 模拟发送命令客户端

	new file:   protocol_api_test.go
	modified:   protocol_test.go
	modified:   protocol_unix.go