### PR TITLE
修复读取buffer时为判断 append后data 长度少于标识长度的情况

### DIFF
--- a/protocol_unix.go
+++ b/protocol_unix.go
@@ -211,6 +211,10 @@ func handleTCPConnection(conn *net.TCPConn, event *Event_T, processLogic func([]
 
 		data = append(data, buffer[:n]...)
 
+		if len(data) < PACKET_IDENTIFY_LEN {
+			continue
+		}
+
 		for string(data[:PACKET_IDENTIFY_LEN]) == PACKET_IDENTIFY {
 			command, headForHash, bodyLength, hashNonce, err = decodeData(data)
 			if err != nil {

--- a/protocol_windows.go
+++ b/protocol_windows.go
@@ -211,6 +211,10 @@ func handleTCPConnection(conn *net.TCPConn, event *Event_T, processLogic func([]
 
 		data = append(data, buffer[:n]...)
 
+		if len(data) < PACKET_IDENTIFY_LEN {
+			continue
+		}
+
 		for string(data[:PACKET_IDENTIFY_LEN]) == PACKET_IDENTIFY {
 			command, headForHash, bodyLength, hashNonce, err = decodeData(data)
 			if err != nil {


### PR DESCRIPTION
	modified:   protocol_unix.go
	modified:   protocol_windows.go